### PR TITLE
V6.2 timerslack+cgroups

### DIFF
--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -2611,7 +2611,7 @@ static int timerslack_ns_show(struct seq_file *m, void *v)
 	}
 
 	task_lock(p);
-	seq_printf(m, "%llu\n", p->timer_slack_ns);
+	seq_printf(m, "%llu\n", get_task_timer_slack_ns(p));
 	task_unlock(p);
 
 out:

--- a/fs/select.c
+++ b/fs/select.c
@@ -75,7 +75,7 @@ static long __estimate_accuracy(struct timespec64 *tv)
 
 u64 select_estimate_accuracy(struct timespec64 *tv)
 {
-	u64 ret;
+	u64 ret, timer_slack;
 	struct timespec64 now;
 
 	/*
@@ -88,8 +88,9 @@ u64 select_estimate_accuracy(struct timespec64 *tv)
 	ktime_get_ts64(&now);
 	now = timespec64_sub(*tv, now);
 	ret = __estimate_accuracy(&now);
-	if (ret < current->timer_slack_ns)
-		return current->timer_slack_ns;
+	timer_slack = get_task_timer_slack_ns(current);
+	if (ret < timer_slack)
+		return timer_slack;
 	return ret;
 }
 

--- a/include/linux/cgroup-defs.h
+++ b/include/linux/cgroup-defs.h
@@ -408,6 +408,15 @@ struct cgroup {
 	int max_descendants;
 
 	/*
+	 * The default process time slacks:
+	 * Setting the timer_slack_ns set's this (and ancestry) cgroups to this
+	 * slack. Defaults to U64_MAX when unset. When timer_slack_ns is unset,
+	 * the parent timer slack from default_timer_slack_ns is used.
+	 */
+	u64 timer_slack_ns;
+	u64 default_timer_slack_ns;
+
+	/*
 	 * Each non-empty css_set associated with this cgroup contributes
 	 * one to nr_populated_csets.  The counter is zero iff this cgroup
 	 * doesn't have any tasks.

--- a/include/linux/cgroup.h
+++ b/include/linux/cgroup.h
@@ -147,6 +147,12 @@ struct cgroup_subsys_state *css_next_child(struct cgroup_subsys_state *pos,
 					   struct cgroup_subsys_state *parent);
 struct cgroup_subsys_state *css_next_descendant_pre(struct cgroup_subsys_state *pos,
 						    struct cgroup_subsys_state *css);
+struct cgroup_subsys_state *
+css_filter_next_descendant_pre(struct cgroup_subsys_state *pos,
+			       struct cgroup_subsys_state *root,
+			       bool (*filter)(struct cgroup_subsys_state *pos, void *data),
+			       void *filter_data);
+
 struct cgroup_subsys_state *css_rightmost_descendant(struct cgroup_subsys_state *pos);
 struct cgroup_subsys_state *css_next_descendant_post(struct cgroup_subsys_state *pos,
 						     struct cgroup_subsys_state *css);
@@ -242,6 +248,11 @@ void css_task_iter_end(struct css_task_iter *it);
 #define css_for_each_descendant_pre(pos, css)				\
 	for ((pos) = css_next_descendant_pre(NULL, (css)); (pos);	\
 	     (pos) = css_next_descendant_pre((pos), (css)))
+
+#define css_filter_for_each_descendant_pre(pos, css, filter, filter_data)            \
+  for ((pos) = css_filter_next_descendant_pre(NULL, (css), (filter), (filter_data)); \
+       (pos);									     \
+       (pos) = css_filter_next_descendant_pre((pos), (css), (filter), (filter_data)))
 
 /**
  * css_for_each_descendant_post - post-order walk of a css's descendants

--- a/include/linux/hrtimer.h
+++ b/include/linux/hrtimer.h
@@ -547,6 +547,12 @@ extern int schedule_hrtimeout(ktime_t *expires, const enum hrtimer_mode mode);
 /* Soft interrupt function to run the hrtimer queues: */
 extern void hrtimer_run_queues(void);
 
+#ifdef CONFIG_HIGH_RES_TIMERS
+extern void hrtimer_run_softexpired_timers(void);
+#else
+static inline void hrtimer_run_softexpired_timers(void) {};
+#endif
+
 /* Bootup initialization: */
 extern void __init hrtimers_init(void);
 

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -1346,9 +1346,11 @@ struct task_struct {
 	/*
 	 * Time slack values; these are used to round up poll() and
 	 * select() etc timeout values. These are in nanoseconds.
+	 * The default timer slack used is 50 usec.
 	 */
 	u64				timer_slack_ns;
 	u64				default_timer_slack_ns;
+#define TASK_TIMER_SLACK_NS          50000
 
 #if defined(CONFIG_KASAN_GENERIC) || defined(CONFIG_KASAN_SW_TAGS)
 	unsigned int			kasan_depth;
@@ -2422,6 +2424,8 @@ extern void sched_set_stop_task(int cpu, struct task_struct *stop);
 
 static inline u64 get_task_timer_slack_ns(const struct task_struct *task)
 {
+	if (task->timer_slack_ns == U64_MAX)
+		return TASK_TIMER_SLACK_NS;
 	return task->timer_slack_ns;
 }
 

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -1347,6 +1347,8 @@ struct task_struct {
 	 * Time slack values; these are used to round up poll() and
 	 * select() etc timeout values. These are in nanoseconds.
 	 * The default timer slack used is 50 usec.
+	 * The effective timer slack should be retrieved with
+	 * get_task_timer_slack_ns(task)
 	 */
 	u64				timer_slack_ns;
 	u64				default_timer_slack_ns;
@@ -2422,10 +2424,19 @@ static inline void sched_core_fork(struct task_struct *p) { }
 
 extern void sched_set_stop_task(int cpu, struct task_struct *stop);
 
+#ifdef CONFIG_CGROUPS
+extern u64 cgroup_timer_slack_ns(const struct task_struct *task);
+#else
+static inline u64 cgroup_timer_slack_ns(const struct task_struct *task)
+{
+	return TASK_TIMER_SLACK_NS;
+}
+#endif
+
 static inline u64 get_task_timer_slack_ns(const struct task_struct *task)
 {
 	if (task->timer_slack_ns == U64_MAX)
-		return TASK_TIMER_SLACK_NS;
+		return cgroup_timer_slack_ns(task);
 	return task->timer_slack_ns;
 }
 

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -2420,4 +2420,9 @@ static inline void sched_core_fork(struct task_struct *p) { }
 
 extern void sched_set_stop_task(int cpu, struct task_struct *stop);
 
+static inline u64 get_task_timer_slack_ns(const struct task_struct *task)
+{
+	return task->timer_slack_ns;
+}
+
 #endif

--- a/include/linux/wait.h
+++ b/include/linux/wait.h
@@ -546,7 +546,7 @@ do {										\
 				      HRTIMER_MODE_REL);			\
 	if ((timeout) != KTIME_MAX) {						\
 		hrtimer_set_expires_range_ns(&__t.timer, timeout,		\
-					current->timer_slack_ns);		\
+					     get_task_timer_slack_ns(current)); \
 		hrtimer_sleeper_start_expires(&__t, HRTIMER_MODE_REL);		\
 	}									\
 										\

--- a/init/init_task.c
+++ b/init/init_task.c
@@ -130,7 +130,7 @@ struct task_struct init_task
 	.journal_info	= NULL,
 	INIT_CPU_TIMERS(init_task)
 	.pi_lock	= __RAW_SPIN_LOCK_UNLOCKED(init_task.pi_lock),
-	.timer_slack_ns = 50000, /* 50 usec default slack */
+	.timer_slack_ns = U64_MAX, /* using default slack */
 	.thread_pid	= &init_struct_pid,
 	.thread_group	= LIST_HEAD_INIT(init_task.thread_group),
 	.thread_node	= LIST_HEAD_INIT(init_signals.thread_head),

--- a/ipc/sem.c
+++ b/ipc/sem.c
@@ -2166,7 +2166,8 @@ long __do_semtimedop(int semid, struct sembuf *sops,
 		rcu_read_unlock();
 
 		timed_out = !schedule_hrtimeout_range(exp,
-				current->timer_slack_ns, HRTIMER_MODE_ABS);
+						      get_task_timer_slack_ns(current),
+						      HRTIMER_MODE_ABS);
 
 		/*
 		 * fastpath: the semop has completed, either successfully or

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -2175,7 +2175,7 @@ static __latent_entropy struct task_struct *copy_process(
 	memset(&p->rss_stat, 0, sizeof(p->rss_stat));
 #endif
 
-	p->default_timer_slack_ns = current->timer_slack_ns;
+	p->default_timer_slack_ns = get_task_timer_slack_ns(current);
 
 #ifdef CONFIG_PSI
 	p->psi_flags = 0;

--- a/kernel/futex/requeue.c
+++ b/kernel/futex/requeue.c
@@ -781,7 +781,7 @@ int futex_wait_requeue_pi(u32 __user *uaddr, unsigned int flags,
 		return -EINVAL;
 
 	to = futex_setup_timer(abs_time, &timeout, flags,
-			       current->timer_slack_ns);
+			       get_task_timer_slack_ns(current));
 
 	/*
 	 * The waiter is allocated on our stack, manipulated by the requeue

--- a/kernel/futex/waitwake.c
+++ b/kernel/futex/waitwake.c
@@ -642,7 +642,7 @@ int futex_wait(u32 __user *uaddr, unsigned int flags, u32 val, ktime_t *abs_time
 	q.bitset = bitset;
 
 	to = futex_setup_timer(abs_time, &timeout, flags,
-			       current->timer_slack_ns);
+			       get_task_timer_slack_ns(current));
 retry:
 	/*
 	 * Prepare to wait on uaddr. On success, it holds hb->lock and q

--- a/kernel/sched/idle.c
+++ b/kernel/sched/idle.c
@@ -170,6 +170,9 @@ static void cpuidle_idle_call(void)
 	struct cpuidle_driver *drv = cpuidle_get_cpu_driver(dev);
 	int next_state, entered_state;
 
+	/* We can avoid the next wakeup by running timers preemptively */
+	hrtimer_run_softexpired_timers();
+
 	/*
 	 * Check if the idle task must be rescheduled. If it is the
 	 * case, exit the function after re-enabling the local irq.

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -3603,7 +3603,8 @@ static int do_sigtimedwait(const sigset_t *which, kernel_siginfo_t *info,
 		spin_unlock_irq(&tsk->sighand->siglock);
 
 		__set_current_state(TASK_INTERRUPTIBLE|TASK_FREEZABLE);
-		ret = schedule_hrtimeout_range(to, tsk->timer_slack_ns,
+		ret = schedule_hrtimeout_range(to,
+					       get_task_timer_slack_ns(tsk),
 					       HRTIMER_MODE_REL);
 		spin_lock_irq(&tsk->sighand->siglock);
 		__set_task_blocked(tsk, &tsk->real_blocked);

--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -2447,10 +2447,10 @@ SYSCALL_DEFINE5(prctl, int, option, unsigned long, arg2, unsigned long, arg3,
 		error = perf_event_task_enable();
 		break;
 	case PR_GET_TIMERSLACK:
-		if (current->timer_slack_ns > ULONG_MAX)
+		if (get_task_timer_slack_ns(current) > ULONG_MAX)
 			error = ULONG_MAX;
 		else
-			error = current->timer_slack_ns;
+			error = get_task_timer_slack_ns(current);
 		break;
 	case PR_SET_TIMERSLACK:
 		if (arg2 <= 0)

--- a/kernel/time/hrtimer.c
+++ b/kernel/time/hrtimer.c
@@ -2198,7 +2198,7 @@ long hrtimer_nanosleep(ktime_t rqtp, const enum hrtimer_mode mode,
 	int ret = 0;
 	u64 slack;
 
-	slack = current->timer_slack_ns;
+	slack = get_task_timer_slack_ns(current);
 	if (dl_task(current) || rt_task(current))
 		slack = 0;
 

--- a/lib/rbtree.c
+++ b/lib/rbtree.c
@@ -424,11 +424,13 @@ EXPORT_SYMBOL(__rb_erase_color);
 static inline void dummy_propagate(struct rb_node *node, struct rb_node *stop) {}
 static inline void dummy_copy(struct rb_node *old, struct rb_node *new) {}
 static inline void dummy_rotate(struct rb_node *old, struct rb_node *new) {}
+static inline void dummy_insert(struct rb_node *parent, struct rb_node *node) {}
 
 static const struct rb_augment_callbacks dummy_callbacks = {
 	.propagate = dummy_propagate,
 	.copy = dummy_copy,
-	.rotate = dummy_rotate
+	.rotate = dummy_rotate,
+	.insert = dummy_insert,
 };
 
 void rb_insert_color(struct rb_node *node, struct rb_root *root)


### PR DESCRIPTION
# Make timer slack useful

## Hrtimer background and problems

Linux has had a concept of "timer slack", but in it's current implementation it only means delaying a timer by a slack time (current default 50 us) . If a process want's to behave nice and set a larger slack, e.g. 1 second, every timer in that process will effectively be delayed by 1 second. This is partly because the hrtimers are sorted by the hard timeout (time + slack) and it would be expensive to peek through all timers to find timers that have soft-expired (i.e. time < now).

This obviously leads to timer slack having no positive effect on power savings as hrtimers can't be expired before the hard timeout and as such always result in a timer interrupt.

## Solution
The solution is to augment the rbtree used to keep hrtimers stored; the timers will be stored in soft-expiry order (i.e. the time without the slack) and the slack will propagate through the augmented rbtree, giving us a chance to figure out the lowest hard timeout (i.e. time + slack) in the tree. This lowest hard timeout is used to program the timer hardware, but now we can opportunistically execute timers that have lower soft-timeouts reducing timer interrupts.

## And another thing (possibly split it out to own PR)...
As timer slack becomes useful, changing the global default timer slack can give some power savings. The other part
adds cgroup support for setting per-cg timer slack. The timer slack is inherited from parent cgroups and can be changed at any point to only affect parts of the cgroup hierarchy.